### PR TITLE
reduce memory on dask workers (again)

### DIFF
--- a/daskhub-rhg/values.yaml
+++ b/daskhub-rhg/values.yaml
@@ -184,7 +184,7 @@ daskhub:
               # `cpus` due to this issue: https://github.com/dask/dask-gateway/issues/364
               # Can update this behavior if that gets addressed
               # standard_cores = 1.75
-              standard_mem = 12.25
+              standard_mem = 11.25
               scaling_factors = {
                   "micro": 0.5,
                   "standard": 1,


### PR DESCRIPTION
Accidentally left 1GB too much on the worker mem requests, which meant that giant workers *still* weren't accessible. This should fix that