### PR TITLE
Fix bad daskgateway pod selector

### DIFF
--- a/daskhub-rhg/values-prod.yaml
+++ b/daskhub-rhg/values-prod.yaml
@@ -34,7 +34,7 @@ daskhub:
             from:
               - podSelector:
                   matchLabels:
-                    gateway.dask.org/instance: "adrastea-dask-gateway"
+                    gateway.dask.org/instance: "daskhub-dask-gateway"
     # this allows dask-gateway pods to talk to the proxy and autohttps pods
     proxy:
       chp:
@@ -46,7 +46,7 @@ daskhub:
               from:
                 - podSelector:
                     matchLabels:
-                      gateway.dask.org/instance: "adrastea-dask-gateway"
+                      gateway.dask.org/instance: "daskhub-dask-gateway"
       traefik:
         networkPolicy:
           ingress:
@@ -56,4 +56,4 @@ daskhub:
               from:
                 - podSelector:
                     matchLabels:
-                      gateway.dask.org/instance: "adrastea-dask-gateway"
+                      gateway.dask.org/instance: "daskhub-dask-gateway"


### PR DESCRIPTION
Fix bad/outdated pod selector needed to allow daskgateway to talk with jupyterhub.

The target pod label appears to be based on the k8s Namespace that daskhub is deployed into. This PR updates it for the current deployment.