### PR TITLE
Add dev env values and README example deployment cmds for argocd

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ argocd app create daskhub \
     --path daskhub-rhg \
     --values values.yaml \
     --values values-prod.yaml \
+    --values values-users.yaml \
     --parameter daskhub.jupyterhub.proxy.service.loadBalancerIP=$JHUB_LOADBALANCERIP \
     --parameter daskhub.jupyterhub.proxy.https.hosts=$JHUB_HOSTS \
     --parameter daskhub.jupyterhub.proxy.secretToken=$JHUB_SECRETTOKEN \
@@ -67,6 +68,7 @@ argocd app create daskhub-dev \
     --path daskhub-rhg \
     --values values.yaml \
     --values values-dev.yaml \
+    --values values-users.yaml \
     --parameter daskhub.jupyterhub.proxy.service.loadBalancerIP=$JHUB_LOADBALANCERIP \
     --parameter daskhub.jupyterhub.proxy.https.hosts=$JHUB_HOSTS \
     --parameter daskhub.jupyterhub.proxy.secretToken=$JHUB_SECRETTOKEN \

--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
 # daskhub-rhg-config
-Daskhub-flavored Jupyterhub deployment configuration.
+Daskhub-flavored Jupyterhub deployment configuration for argocd.
 
 This is a demonstration sandbox.
 
-
+## Fresh deployment
 Deploy the app fresh, using automated syncing, with `argocd` from the CLI with:
 
 ```
-export JHUB_LOADBALANCERIP="127.0. 0.1"
+export JHUB_LOADBALANCERIP="127.0.0.1"
 export JHUB_HOSTS="{fakewebsite.com}"
 export JHUB_SECRETTOKEN="fakenumbers"
 export JHUB_CLIENTID="abc999"
@@ -15,11 +15,13 @@ export JHUB_CLIENTSECRET="cba666"
 export JHUB_CALLBACKURL="https://fakewebsite.com/hub/oauth_callback"
 export DASK_APITOKEN="xyz111"
 export JHUB_APITOKEN="zyx222"
+export DEPLOY_NAMESPACE="daskhub"
+export DEPLOY_REVISION="v1.2.3"
 
-kubectl create namespace daskhub
+kubectl create namespace $DEPLOY_NAMESPACE
 argocd app create daskhub \
     --repo https://github.com/RhodiumGroup/daskhub-rhg-config.git \
-    --revision main \
+    --revision $DEPLOY_REVISION \
     --path daskhub-rhg \
     --values values.yaml \
     --values values-prod.yaml \
@@ -32,8 +34,45 @@ argocd app create daskhub \
     --parameter daskhub.jupyterhub.hub.services.dask-gateway.apiToken=$DASK_APITOKEN \
     --parameter daskhub.dask-gateway.gateway.auth.jupyterhub.apiToken=$JHUB_APITOKEN \ 
     --dest-server https://kubernetes.default.svc \
-    --dest-namespace daskhub \
+    --dest-namespace $DEPLOY_NAMESPACE \
     --sync-policy automated \
     --auto-prune \
     --port-forward-namespace argocd
 ```
+
+This will automatically sync to to git tag "v1.2.3". You can alternatively deploy tracking the `main` branch with
+
+```
+export JHUB_LOADBALANCERIP="127.0.0.1"
+export JHUB_HOSTS="{fakewebsite-dev.com}"
+export JHUB_SECRETTOKEN="otherfakenumbers"
+export JHUB_CLIENTID="abc999"
+export JHUB_CLIENTSECRET="cba666"
+export JHUB_CALLBACKURL="https://fakewebsite-dev.com/hub/oauth_callback"
+export DASK_APITOKEN="xyz111"
+export JHUB_APITOKEN="zyx222"
+export DEPLOY_NAMESPACE="daskhub-dev"
+
+kubectl create namespace $DEPLOY_NAMESPACE
+argocd app create daskhub-dev \
+    --repo https://github.com/RhodiumGroup/daskhub-rhg-config.git \
+    --revision main \
+    --path daskhub-rhg \
+    --values values.yaml \
+    --values values-dev.yaml \
+    --parameter daskhub.jupyterhub.proxy.service.loadBalancerIP=$JHUB_LOADBALANCERIP \
+    --parameter daskhub.jupyterhub.proxy.https.hosts=$JHUB_HOSTS \
+    --parameter daskhub.jupyterhub.proxy.secretToken=$JHUB_SECRETTOKEN \
+    --parameter daskhub.jupyterhub.hub.config.GitHubOAuthenticator.client_id=$JHUB_CLIENTID \
+    --parameter daskhub.jupyterhub.hub.config.GitHubOAuthenticator.client_secret=$JHUB_CLIENTSECRET \
+    --parameter daskhub.jupyterhub.hub.config.GitHubOAuthenticator.oauth_callback_url=$JHUB_CALLBACKURL \
+    --parameter daskhub.jupyterhub.hub.services.dask-gateway.apiToken=$DASK_APITOKEN \
+    --parameter daskhub.dask-gateway.gateway.auth.jupyterhub.apiToken=$JHUB_APITOKEN \ 
+    --dest-server https://kubernetes.default.svc \
+    --dest-namespace $DEPLOY_NAMESPACE \
+    --sync-policy automated \
+    --auto-prune \
+    --port-forward-namespace argocd
+```
+
+This uses `dev` environment values for the helm chart and deploys to a `daskhub-dev` namespace.

--- a/README.md
+++ b/README.md
@@ -32,7 +32,8 @@ argocd app create daskhub \
     --parameter daskhub.jupyterhub.hub.config.GitHubOAuthenticator.client_secret=$JHUB_CLIENTSECRET \
     --parameter daskhub.jupyterhub.hub.config.GitHubOAuthenticator.oauth_callback_url=$JHUB_CALLBACKURL \
     --parameter daskhub.jupyterhub.hub.services.dask-gateway.apiToken=$DASK_APITOKEN \
-    --parameter daskhub.dask-gateway.gateway.auth.jupyterhub.apiToken=$JHUB_APITOKEN \ 
+    --parameter daskhub.dask-gateway.gateway.auth.jupyterhub.apiToken=$JHUB_APITOKEN \
+    --label env=prod \
     --dest-server https://kubernetes.default.svc \
     --dest-namespace $DEPLOY_NAMESPACE \
     --sync-policy automated \
@@ -67,7 +68,8 @@ argocd app create daskhub-dev \
     --parameter daskhub.jupyterhub.hub.config.GitHubOAuthenticator.client_secret=$JHUB_CLIENTSECRET \
     --parameter daskhub.jupyterhub.hub.config.GitHubOAuthenticator.oauth_callback_url=$JHUB_CALLBACKURL \
     --parameter daskhub.jupyterhub.hub.services.dask-gateway.apiToken=$DASK_APITOKEN \
-    --parameter daskhub.dask-gateway.gateway.auth.jupyterhub.apiToken=$JHUB_APITOKEN \ 
+    --parameter daskhub.dask-gateway.gateway.auth.jupyterhub.apiToken=$JHUB_APITOKEN \
+    --label env=dev \
     --dest-server https://kubernetes.default.svc \
     --dest-namespace $DEPLOY_NAMESPACE \
     --sync-policy automated \

--- a/README.md
+++ b/README.md
@@ -40,7 +40,14 @@ argocd app create daskhub \
     --port-forward-namespace argocd
 ```
 
-This will automatically sync to to git tag "v1.2.3". You can alternatively deploy tracking the `main` branch with
+This will automatically sync to to git tag "v1.2.3". When a new tag is created, you can set the app to sync to this tag with
+
+```
+argocd app set daskhub --revision <new-tag> --port-forward-namespace argocd
+```
+
+
+Alternatively, you can deploy an app tracking the `main` branch with
 
 ```
 export JHUB_LOADBALANCERIP="127.0.0.1"

--- a/README.md
+++ b/README.md
@@ -33,7 +33,6 @@ argocd app create daskhub \
     --parameter daskhub.jupyterhub.hub.config.GitHubOAuthenticator.oauth_callback_url=$JHUB_CALLBACKURL \
     --parameter daskhub.jupyterhub.hub.services.dask-gateway.apiToken=$DASK_APITOKEN \
     --parameter daskhub.dask-gateway.gateway.auth.jupyterhub.apiToken=$JHUB_APITOKEN \
-    --label env=prod \
     --dest-server https://kubernetes.default.svc \
     --dest-namespace $DEPLOY_NAMESPACE \
     --sync-policy automated \
@@ -69,7 +68,6 @@ argocd app create daskhub-dev \
     --parameter daskhub.jupyterhub.hub.config.GitHubOAuthenticator.oauth_callback_url=$JHUB_CALLBACKURL \
     --parameter daskhub.jupyterhub.hub.services.dask-gateway.apiToken=$DASK_APITOKEN \
     --parameter daskhub.dask-gateway.gateway.auth.jupyterhub.apiToken=$JHUB_APITOKEN \
-    --label env=dev \
     --dest-server https://kubernetes.default.svc \
     --dest-namespace $DEPLOY_NAMESPACE \
     --sync-policy automated \

--- a/daskhub-rhg/values-dev.yaml
+++ b/daskhub-rhg/values-dev.yaml
@@ -1,0 +1,59 @@
+# Helm chart values for the prod environment
+daskhub:
+  jupyterhub:
+    hub:
+      config:
+        Authenticator:
+          admin_users:
+            - bolliger32
+            - brews
+            - delgadom
+            - dgergel
+            - mattgoldklang
+          allowed_users:
+            # rhg employees
+            - ahamidi1
+            - hanskolus
+            - hhessRHG
+            - jk-sohal
+            - kemccusker
+            - rhg-smohan
+            - smohan-rhg
+            - tghouser
+            - wjherndon
+            # external collaborators
+            - dpa9694
+            - jtschoi
+            - njdepsky
+  # this allows the dask-gateway pods to talk to the hub
+      networkPolicy:
+        ingress:
+          - ports:
+            - port: http
+            - port: https
+            from:
+              - podSelector:
+                  matchLabels:
+                    gateway.dask.org/instance: "adrastea-dask-gateway"
+    # this allows dask-gateway pods to talk to the proxy and autohttps pods
+    proxy:
+      chp:
+        networkPolicy:
+          ingress:
+            - ports:
+              - port: http
+              - port: https
+              from:
+                - podSelector:
+                    matchLabels:
+                      gateway.dask.org/instance: "adrastea-dask-gateway"
+      traefik:
+        networkPolicy:
+          ingress:
+            - ports:
+              - port: http
+              - port: https
+              from:
+                - podSelector:
+                    matchLabels:
+                      gateway.dask.org/instance: "adrastea-dask-gateway"

--- a/daskhub-rhg/values-dev.yaml
+++ b/daskhub-rhg/values-dev.yaml
@@ -2,29 +2,6 @@
 daskhub:
   jupyterhub:
     hub:
-      config:
-        Authenticator:
-          admin_users:
-            - bolliger32
-            - brews
-            - delgadom
-            - dgergel
-            - mattgoldklang
-          allowed_users:
-            # rhg employees
-            - ahamidi1
-            - hanskolus
-            - hhessRHG
-            - jk-sohal
-            - kemccusker
-            - rhg-smohan
-            - smohan-rhg
-            - tghouser
-            - wjherndon
-            # external collaborators
-            - dpa9694
-            - jtschoi
-            - njdepsky
   # this allows the dask-gateway pods to talk to the hub
       networkPolicy:
         ingress:

--- a/daskhub-rhg/values-dev.yaml
+++ b/daskhub-rhg/values-dev.yaml
@@ -34,7 +34,7 @@ daskhub:
             from:
               - podSelector:
                   matchLabels:
-                    gateway.dask.org/instance: "adrastea-dask-gateway"
+                    gateway.dask.org/instance: "daskhub-dev-dask-gateway"
     # this allows dask-gateway pods to talk to the proxy and autohttps pods
     proxy:
       chp:
@@ -46,7 +46,7 @@ daskhub:
               from:
                 - podSelector:
                     matchLabels:
-                      gateway.dask.org/instance: "adrastea-dask-gateway"
+                      gateway.dask.org/instance: "daskhub-dev-dask-gateway"
       traefik:
         networkPolicy:
           ingress:
@@ -56,4 +56,4 @@ daskhub:
               from:
                 - podSelector:
                     matchLabels:
-                      gateway.dask.org/instance: "adrastea-dask-gateway"
+                      gateway.dask.org/instance: "daskhub-dev-dask-gateway"

--- a/daskhub-rhg/values-prod.yaml
+++ b/daskhub-rhg/values-prod.yaml
@@ -2,29 +2,6 @@
 daskhub:
   jupyterhub:
     hub:
-      config:
-        Authenticator:
-          admin_users:
-            - bolliger32
-            - brews
-            - delgadom
-            - dgergel
-            - mattgoldklang
-          allowed_users:
-            # rhg employees
-            - ahamidi1
-            - hanskolus
-            - hhessRHG
-            - jk-sohal
-            - kemccusker
-            - rhg-smohan
-            - smohan-rhg
-            - tghouser
-            - wjherndon
-            # external collaborators
-            - dpa9694
-            - jtschoi
-            - njdepsky
   # this allows the dask-gateway pods to talk to the hub
       networkPolicy:
         ingress:

--- a/daskhub-rhg/values-prod.yaml
+++ b/daskhub-rhg/values-prod.yaml
@@ -34,7 +34,7 @@ daskhub:
             from:
               - podSelector:
                   matchLabels:
-                    gateway.dask.org/instance: "adrastea-dask-gateway"
+                    gateway.dask.org/instance: "daskhub-dask-gateway"
     # this allows dask-gateway pods to talk to the proxy and autohttps pods
     proxy:
       chp:
@@ -46,7 +46,7 @@ daskhub:
               from:
                 - podSelector:
                     matchLabels:
-                      gateway.dask.org/instance: "adrastea-dask-gateway"
+                      gateway.dask.org/instance: "daskhub-dask-gateway"
       traefik:
         networkPolicy:
           ingress:
@@ -56,4 +56,4 @@ daskhub:
               from:
                 - podSelector:
                     matchLabels:
-                      gateway.dask.org/instance: "adrastea-dask-gateway"
+                      gateway.dask.org/instance: "daskhub-dask-gateway"

--- a/daskhub-rhg/values-users.yaml
+++ b/daskhub-rhg/values-users.yaml
@@ -1,0 +1,26 @@
+daskhub:
+  jupyterhub:
+    hub:
+      config:
+        Authenticator:
+          admin_users:
+            - bolliger32
+            - brews
+            - delgadom
+            - dgergel
+            - mattgoldklang
+          allowed_users:
+            # rhg employees
+            - ahamidi1
+            - hanskolus
+            - hhessRHG
+            - jk-sohal
+            - kemccusker
+            - rhg-smohan
+            - smohan-rhg
+            - tghouser
+            - wjherndon
+            # external collaborators
+            - dpa9694
+            - jtschoi
+            - njdepsky

--- a/daskhub-rhg/values.yaml
+++ b/daskhub-rhg/values.yaml
@@ -140,28 +140,6 @@ daskhub:
         dask-gateway:
           apiToken: OVERRIDEME
       config:
-        Authenticator:
-          admin_users:
-            - bolliger32
-            - brews
-            - delgadom
-            - dgergel
-            - mattgoldklang
-          allowed_users:
-            # rhg employees
-            - ahamidi1
-            - hanskolus
-            - hhessRHG
-            - jk-sohal
-            - kemccusker
-            - rhg-smohan
-            - smohan-rhg
-            - tghouser
-            - wjherndon
-            # external collaborators
-            - dpa9694
-            - jtschoi
-            - njdepsky
         JupyterHub:
           admin_access: true
           authenticator_class: github

--- a/daskhub-rhg/values.yaml
+++ b/daskhub-rhg/values.yaml
@@ -140,6 +140,28 @@ daskhub:
         dask-gateway:
           apiToken: OVERRIDEME
       config:
+        Authenticator:
+          admin_users:
+            - bolliger32
+            - brews
+            - delgadom
+            - dgergel
+            - mattgoldklang
+          allowed_users:
+            # rhg employees
+            - ahamidi1
+            - hanskolus
+            - hhessRHG
+            - jk-sohal
+            - kemccusker
+            - rhg-smohan
+            - smohan-rhg
+            - tghouser
+            - wjherndon
+            # external collaborators
+            - dpa9694
+            - jtschoi
+            - njdepsky
         JupyterHub:
           admin_access: true
           authenticator_class: github


### PR DESCRIPTION
Add helm chart values yaml file for a hypothetical `dev` environment.

Also add example `argocd` commands to deploy the `dev` values app into its own k8s Namespace, tracking development on the `main` branch.