### PR TITLE
bump daskhub dependent chart and update scheduler_cores max

### DIFF
--- a/daskhub-rhg/Chart.yaml
+++ b/daskhub-rhg/Chart.yaml
@@ -6,15 +6,15 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.0.1
+version: 0.1.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "0.0.1"
+appVersion: "0.1.0"
 
 dependencies:
   - name: daskhub
-    version: "4.5.7"
+    version: "4.5.8"
     repository: 'https://helm.dask.org'

--- a/daskhub-rhg/values.yaml
+++ b/daskhub-rhg/values.yaml
@@ -287,7 +287,7 @@ daskhub:
                   Mapping("extra_worker_labels", default={}, label="Extra Worker Pod Labels"),
                   Mapping("env_items", default={}, label="Environment Variables"),
                   String("scheduler_memory", default="22.5 G", label="Scheduler Memory"),
-                  Float("scheduler_cores", default=3.5, min=1, max=7, label="Scheduler CPUs"),
+                  Float("scheduler_cores", default=3.5, min=1, max=8, label="Scheduler CPUs"),
                   handler=option_handler,
               )
           c.Backend.cluster_options = cluster_options


### PR DESCRIPTION
Dask released a new daskhub chart and so I'm bumping our dependency to pull in the new version.

Also realized that you could not spin up a cluster from a "large" notebook instance due to bounds on our scheduler size, so I fixed that.