### PR TITLE
make all pods a BIT smaller

### DIFF
--- a/daskhub-rhg/values.yaml
+++ b/daskhub-rhg/values.yaml
@@ -19,8 +19,8 @@ daskhub:
       storage:
         capacity: 10Gi
       cpu:
-        limit: 3.75
-        guarantee: 3.75
+        limit: 3.7
+        guarantee: 3.7
       memory:
         limit: 22.5G
         guarantee: 22.5G
@@ -33,8 +33,8 @@ daskhub:
         - display_name: "Rhodium base: stable (large)"
           description: "Larger notebook allowance, with the stable build of <a href=\"https://gitlab.com/rhodium/infra_management/google/jupyterhub-images/docker_images\">docker_images@master</a> (v1.0.0)"
           kubespawner_override:
-            cpu_limit: 7.5
-            cpu_guarantee: 7.5
+            cpu_limit: 7.4
+            cpu_guarantee: 7.4
             mem_limit: 45G
             mem_guarantee: 45G
         - display_name: "Rhodium base: latest"
@@ -45,8 +45,8 @@ daskhub:
           description: "Larger notebook allowance, with the latest build of <a href=\"https://gitlab.com/rhodium/infra_management/google/jupyterhub-images/docker_images\">docker_images@master</a>"
           kubespawner_override:
             image: gcr.io/rhg-project-1/notebook:latest
-            cpu_limit: 7.5
-            cpu_guarantee: 7.5
+            cpu_limit: 7.4
+            cpu_guarantee: 7.4
             mem_limit: 45G
             mem_guarantee: 45G
         - display_name: "Octave: stable"
@@ -57,8 +57,8 @@ daskhub:
           description: "Larger notebook allowance, with the stable build our Octave-enabled environment (v1.0.0)"
           kubespawner_override:
             image: gcr.io/rhg-project-1/notebook:v1.0.0-octave
-            cpu_limit: 7.5
-            cpu_guarantee: 7.5
+            cpu_limit: 7.4
+            cpu_guarantee: 7.4
             mem_limit: 45G
             mem_guarantee: 45G
         - display_name: "Octave: latest"
@@ -69,8 +69,8 @@ daskhub:
           description: "Larger notebook allowance, with the latest build our Octave-enabled environment"
           kubespawner_override:
             image: gcr.io/rhg-project-1/notebook:octave
-            cpu_limit: 7.5
-            cpu_guarantee: 7.5
+            cpu_limit: 7.4
+            cpu_guarantee: 7.4
             mem_limit: 45G
             mem_guarantee: 45G
         - display_name: "Coastal: stable"
@@ -81,8 +81,8 @@ daskhub:
           description: "Larger notebook allowance, with the stable build our Coastal project environment (v1.0.0)"
           kubespawner_override:
             image: gcr.io/rhg-project-1/notebook:v1.0.0-coastal
-            cpu_limit: 7.5
-            cpu_guarantee: 7.5
+            cpu_limit: 7.4
+            cpu_guarantee: 7.4
             mem_limit: 45G
             mem_guarantee: 45G
         - display_name: "Coastal: latest"
@@ -93,8 +93,8 @@ daskhub:
           description: "Larger notebook allowance, with the latest build of our Coastal project environment"
           kubespawner_override:
             image: gcr.io/rhg-project-1/notebook:coastal
-            cpu_limit: 7.5
-            cpu_guarantee: 7.5
+            cpu_limit: 7.4
+            cpu_guarantee: 7.4
             mem_limit: 45G
             mem_guarantee: 45G
         # uncomment test image to run tests (typically just on adrastea)
@@ -287,7 +287,7 @@ daskhub:
                   Mapping("extra_worker_labels", default={}, label="Extra Worker Pod Labels"),
                   Mapping("env_items", default={}, label="Environment Variables"),
                   String("scheduler_memory", default="22.5 G", label="Scheduler Memory"),
-                  Float("scheduler_cores", default=3.5, min=1, max=8, label="Scheduler CPUs"),
+                  Float("scheduler_cores", default=3.7, min=1, max=8, label="Scheduler CPUs"),
                   handler=option_handler,
               )
           c.Backend.cluster_options = cluster_options


### PR DESCRIPTION
@delgadom was getting insufficient CPU errors when trying to instantiate a scheduler from a big notebook (7.5 vCPUs). Turns out we were RIGHT at the edge of having enough CPUS (7.91 allocatable and .413 overhead processes). So we're just bumping everything down slightly so that big notebooks are at 7.4 and are still 2x the standard notebooks.