### PR TITLE
smaller notebook CPU requests

### DIFF
--- a/daskhub-rhg/values.yaml
+++ b/daskhub-rhg/values.yaml
@@ -19,8 +19,8 @@ daskhub:
       storage:
         capacity: 10Gi
       cpu:
-        limit: 3.7
-        guarantee: 3.7
+        limit: 3.5
+        guarantee: 3.5
       memory:
         limit: 22.5G
         guarantee: 22.5G
@@ -33,8 +33,8 @@ daskhub:
         - display_name: "Rhodium base: stable (large)"
           description: "Larger notebook allowance, with the stable build of <a href=\"https://gitlab.com/rhodium/infra_management/google/jupyterhub-images/docker_images\">docker_images@master</a> (v1.0.0)"
           kubespawner_override:
-            cpu_limit: 7.4
-            cpu_guarantee: 7.4
+            cpu_limit: 7
+            cpu_guarantee: 7
             mem_limit: 45G
             mem_guarantee: 45G
         - display_name: "Rhodium base: latest"
@@ -45,8 +45,8 @@ daskhub:
           description: "Larger notebook allowance, with the latest build of <a href=\"https://gitlab.com/rhodium/infra_management/google/jupyterhub-images/docker_images\">docker_images@master</a>"
           kubespawner_override:
             image: gcr.io/rhg-project-1/notebook:latest
-            cpu_limit: 7.4
-            cpu_guarantee: 7.4
+            cpu_limit: 7
+            cpu_guarantee: 7
             mem_limit: 45G
             mem_guarantee: 45G
         - display_name: "Octave: stable"
@@ -57,8 +57,8 @@ daskhub:
           description: "Larger notebook allowance, with the stable build our Octave-enabled environment (v1.0.0)"
           kubespawner_override:
             image: gcr.io/rhg-project-1/notebook:v1.0.0-octave
-            cpu_limit: 7.4
-            cpu_guarantee: 7.4
+            cpu_limit: 7
+            cpu_guarantee: 7
             mem_limit: 45G
             mem_guarantee: 45G
         - display_name: "Octave: latest"
@@ -69,8 +69,8 @@ daskhub:
           description: "Larger notebook allowance, with the latest build our Octave-enabled environment"
           kubespawner_override:
             image: gcr.io/rhg-project-1/notebook:octave
-            cpu_limit: 7.4
-            cpu_guarantee: 7.4
+            cpu_limit: 7
+            cpu_guarantee: 7
             mem_limit: 45G
             mem_guarantee: 45G
         - display_name: "Coastal: stable"
@@ -81,8 +81,8 @@ daskhub:
           description: "Larger notebook allowance, with the stable build our Coastal project environment (v1.0.0)"
           kubespawner_override:
             image: gcr.io/rhg-project-1/notebook:v1.0.0-coastal
-            cpu_limit: 7.4
-            cpu_guarantee: 7.4
+            cpu_limit: 7
+            cpu_guarantee: 7
             mem_limit: 45G
             mem_guarantee: 45G
         - display_name: "Coastal: latest"
@@ -93,8 +93,8 @@ daskhub:
           description: "Larger notebook allowance, with the latest build of our Coastal project environment"
           kubespawner_override:
             image: gcr.io/rhg-project-1/notebook:coastal
-            cpu_limit: 7.4
-            cpu_guarantee: 7.4
+            cpu_limit: 7
+            cpu_guarantee: 7
             mem_limit: 45G
             mem_guarantee: 45G
         # uncomment test image to run tests (typically just on adrastea)


### PR DESCRIPTION
Notebooks seem to be getting some sigterms while running a large dask cluster. My guess is that some k8s process is being loaded onto the node with the notebook pod and is taking priority, which is pushing the node's CPU requests over the total allowable number and booting off the notebook pod. Trying 3.5 vCPU instead of 3.7 vCPU for a standard size (7 instead of 7.4 for a "large" size notebook).