### PR TITLE
fix daskhub vers

### DIFF
--- a/daskhub-rhg/Chart.yaml
+++ b/daskhub-rhg/Chart.yaml
@@ -16,5 +16,5 @@ appVersion: "0.1.1"
 
 dependencies:
   - name: daskhub
-    version: "2021.6.2"
+    version: "2021.6.1"
     repository: 'https://helm.dask.org'

--- a/daskhub-rhg/values.yaml
+++ b/daskhub-rhg/values.yaml
@@ -19,8 +19,8 @@ daskhub:
       storage:
         capacity: 10Gi
       cpu:
-        limit: 3.5
-        guarantee: 3.5
+        limit: 3.6
+        guarantee: 3.6
       memory:
         limit: 22.5G
         guarantee: 22.5G
@@ -33,8 +33,8 @@ daskhub:
         - display_name: "Rhodium base: stable (large)"
           description: "Larger notebook allowance, with the stable build of <a href=\"https://gitlab.com/rhodium/infra_management/google/jupyterhub-images/docker_images\">docker_images@master</a> (v1.0.0)"
           kubespawner_override:
-            cpu_limit: 7
-            cpu_guarantee: 7
+            cpu_limit: 7.2
+            cpu_guarantee: 7.2
             mem_limit: 45G
             mem_guarantee: 45G
         - display_name: "Rhodium base: latest"
@@ -45,8 +45,8 @@ daskhub:
           description: "Larger notebook allowance, with the latest build of <a href=\"https://gitlab.com/rhodium/infra_management/google/jupyterhub-images/docker_images\">docker_images@master</a>"
           kubespawner_override:
             image: gcr.io/rhg-project-1/notebook:latest
-            cpu_limit: 7
-            cpu_guarantee: 7
+            cpu_limit: 7.2
+            cpu_guarantee: 7.2
             mem_limit: 45G
             mem_guarantee: 45G
         - display_name: "Octave: stable"
@@ -57,8 +57,8 @@ daskhub:
           description: "Larger notebook allowance, with the stable build our Octave-enabled environment (v1.0.0)"
           kubespawner_override:
             image: gcr.io/rhg-project-1/notebook:v1.0.0-octave
-            cpu_limit: 7
-            cpu_guarantee: 7
+            cpu_limit: 7.2
+            cpu_guarantee: 7.2
             mem_limit: 45G
             mem_guarantee: 45G
         - display_name: "Octave: latest"
@@ -69,8 +69,8 @@ daskhub:
           description: "Larger notebook allowance, with the latest build our Octave-enabled environment"
           kubespawner_override:
             image: gcr.io/rhg-project-1/notebook:octave
-            cpu_limit: 7
-            cpu_guarantee: 7
+            cpu_limit: 7.2
+            cpu_guarantee: 7.2
             mem_limit: 45G
             mem_guarantee: 45G
         - display_name: "Coastal: stable"
@@ -81,8 +81,8 @@ daskhub:
           description: "Larger notebook allowance, with the stable build our Coastal project environment (v1.0.0)"
           kubespawner_override:
             image: gcr.io/rhg-project-1/notebook:v1.0.0-coastal
-            cpu_limit: 7
-            cpu_guarantee: 7
+            cpu_limit: 7.2
+            cpu_guarantee: 7.2
             mem_limit: 45G
             mem_guarantee: 45G
         - display_name: "Coastal: latest"
@@ -93,8 +93,8 @@ daskhub:
           description: "Larger notebook allowance, with the latest build of our Coastal project environment"
           kubespawner_override:
             image: gcr.io/rhg-project-1/notebook:coastal
-            cpu_limit: 7
-            cpu_guarantee: 7
+            cpu_limit: 7.2
+            cpu_guarantee: 7.2
             mem_limit: 45G
             mem_guarantee: 45G
         # uncomment test image to run tests (typically just on adrastea)


### PR DESCRIPTION
Earlier commit (which was accidentally force-pushed to main so doesn't have a PR) updated daskhub to version 2021.6.2. This is the version of dask that is used on the latest version of the daskhub helm chart, but the helm chart version itself is 2021.6.1. So this was creating an error.

Also, following up #25 by trying 3.6 CPU by default (previous PR moved from 3.7 to 3.5 but why not try a smaller drop first).