### PR TITLE
update readme to remove secrettoken

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ This sets up `argocd` for minimalist and dev envrionments, to be interacted with
 
 ### Deploying apps
 
-**NOTE:** For each of the following deployment workflows, if deploying with daskhub version 2021.6.0 or earlier, you will also need to pass the parameter override `daskhub.jupyterhub.proxy.secretToken`. You will need to pass this parameter following your first upgrade to 2021.6.1 or later, but afterwards you no longer need the parameter override.
+**NOTE:** For each of the following deployment workflows, if deploying with daskhub version 2021.6.0 or earlier, you will also need to pass the parameter override `daskhub.jupyterhub.proxy.secretToken`. You will need to pass this parameter following your first upgrade to 2021.6.1 or later, but afterwards you no longer need the parameter override. See [https://github.com/jupyterhub/zero-to-jupyterhub-k8s/blob/main/CHANGELOG.md#highlights](https://github.com/jupyterhub/zero-to-jupyterhub-k8s/blob/main/CHANGELOG.md#highlights).
 
 Deploy the app fresh, using automated syncing, with `argocd` from the CLI with:
 

--- a/README.md
+++ b/README.md
@@ -16,12 +16,14 @@ kubectl patch deploy argocd-server -n argocd -p '[{"op": "add", "path": "/spec/t
 This sets up `argocd` for minimalist and dev envrionments, to be interacted with through the `argocd` CLI.
 
 ### Deploying apps
+
+**NOTE:** For each of the following deployment workflows, if deploying with daskhub version 2021.6.0 or earlier, you will also need to pass the parameter override `daskhub.jupyterhub.proxy.secretToken`. You will need to pass this parameter following your first upgrade to 2021.6.1 or later, but afterwards you no longer need the parameter override.
+
 Deploy the app fresh, using automated syncing, with `argocd` from the CLI with:
 
 ```bash
 export JHUB_LOADBALANCERIP="127.0.0.1"
 export JHUB_HOSTS="{fakewebsite.com}"
-export JHUB_SECRETTOKEN="fakenumbers"
 export JHUB_CLIENTID="abc999"
 export JHUB_CLIENTSECRET="cba666"
 export JHUB_CALLBACKURL="https://fakewebsite.com/hub/oauth_callback"
@@ -39,7 +41,6 @@ argocd app create daskhub \
     --values values-users.yaml \
     --parameter daskhub.jupyterhub.proxy.service.loadBalancerIP=$JHUB_LOADBALANCERIP \
     --parameter daskhub.jupyterhub.proxy.https.hosts=$JHUB_HOSTS \
-    --parameter daskhub.jupyterhub.proxy.secretToken=$JHUB_SECRETTOKEN \
     --parameter daskhub.jupyterhub.hub.config.GitHubOAuthenticator.client_id=$JHUB_CLIENTID \
     --parameter daskhub.jupyterhub.hub.config.GitHubOAuthenticator.client_secret=$JHUB_CLIENTSECRET \
     --parameter daskhub.jupyterhub.hub.config.GitHubOAuthenticator.oauth_callback_url=$JHUB_CALLBACKURL \
@@ -65,7 +66,6 @@ Alternatively, you can deploy an app tracking the `main` branch with
 ```bash
 export JHUB_LOADBALANCERIP="127.0.0.1"
 export JHUB_HOSTS="{fakewebsite-dev.com}"
-export JHUB_SECRETTOKEN="otherfakenumbers"
 export JHUB_CLIENTID="abc999"
 export JHUB_CLIENTSECRET="cba666"
 export JHUB_CALLBACKURL="https://fakewebsite-dev.com/hub/oauth_callback"
@@ -82,7 +82,6 @@ argocd app create daskhub-dev \
     --values values-users.yaml \
     --parameter daskhub.jupyterhub.proxy.service.loadBalancerIP=$JHUB_LOADBALANCERIP \
     --parameter daskhub.jupyterhub.proxy.https.hosts=$JHUB_HOSTS \
-    --parameter daskhub.jupyterhub.proxy.secretToken=$JHUB_SECRETTOKEN \
     --parameter daskhub.jupyterhub.hub.config.GitHubOAuthenticator.client_id=$JHUB_CLIENTID \
     --parameter daskhub.jupyterhub.hub.config.GitHubOAuthenticator.client_secret=$JHUB_CLIENTSECRET \
     --parameter daskhub.jupyterhub.hub.config.GitHubOAuthenticator.oauth_callback_url=$JHUB_CALLBACKURL \


### PR DESCRIPTION
As of daskhub 2021.6.1, which updates the jupyterhub chart to 1.4.1 and the jupyterhub app to 1.0.1, we no longer need to explicitly pass jupyterhub.proxy.secretToken, except for the first deployment following this upgrade (see [the jupyterhub chart changelog](https://github.com/jupyterhub/zero-to-jupyterhub-k8s/blob/main/CHANGELOG.md#highlights)).

I've updated the README to remove that parameter override from the instructions to set up a deployment, but added a note describing that this parameter is needed for the first time you upgrade to daskhub 2021.6.1 or later.

Adrastea has already received this upgrade and the argocd parameter override for this parameter has already been unset (or at least, I think I did that correctly). On compute-rhg, we are not yet using this repo or argoCD. The first time that cluster gets a daskhub upgrade to >=2021.6.1 we will need to pass the secretToken parameter. After that, we can probably remove this extra note from the readme since it will no longer be relevant for any future deployments