### PR TITLE
bump daskhub to 2021.7.2

### DIFF
--- a/daskhub-rhg/Chart.yaml
+++ b/daskhub-rhg/Chart.yaml
@@ -16,5 +16,5 @@ appVersion: "0.1.1"
 
 dependencies:
   - name: daskhub
-    version: "2021.7.1"
+    version: "2021.7.2"
     repository: 'https://helm.dask.org'


### PR DESCRIPTION
includes bump of jupyterhub helm chart from 1.0.1 to 1.1.1