### PR TITLE
Add k8s.dask.org/dedicated tolerations

### DIFF
--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -103,7 +103,14 @@ daskhub:
                       "operator": "Equal",
                       "value": "worker",
                       "effect": "NoSchedule"
+                  },
+                  "1": {
+                      "key": "k8s.dask.org/dedicated",
+                      "operator": "Equal",
+                      "value": "worker",
+                      "effect": "NoSchedule"
                   }
+
               }
 
               # put scheduler in jupyter pool to make it non-preemptible
@@ -113,7 +120,14 @@ daskhub:
                       "operator": "Equal",
                       "value": "user",
                       "effect": "NoSchedule"
+                  },
+                  {
+                      "key": "hub.jupyter.org/dedicated",
+                      "operator": "Equal",
+                      "value": "user",
+                      "effect": "NoSchedule"
                   }
+
               ]
 
               def option_handler(options):


### PR DESCRIPTION
Gives dask component tolerations with both the `k8s.dask.org/dedicated` and `k8s.dask.org_dedicated` key. Previously, it just tolerated `k8s.dask.org_dedicated`.